### PR TITLE
Improve site with responsive menu and theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSRS Guide
 
-A comprehensive resource for leveling and end-game preparation in **Old School RuneScape (OSRS)**. This repository hosts the original "OSRS Max Level and End-Game Preparation Guide" PDF and a static website that highlights the material in web form. The site now includes a basic experience calculator and persistent checklists. It also serves as the base for future improvements such as more advanced interactive tools and detailed training breakdowns.
+A comprehensive resource for leveling and end-game preparation in **Old School RuneScape (OSRS)**. This repository hosts the original "OSRS Max Level and End-Game Preparation Guide" PDF and a static website that highlights the material in web form. The site includes calculators, persistent checklists, a mobile-friendly navigation menu, and a light/dark theme toggle. It also serves as the base for future improvements such as more advanced interactive tools and detailed training breakdowns.
 
 ## Contents
 
@@ -98,7 +98,7 @@ Future iterations might introduce a build step or tooling (such as a static site
 ## Roadmap
 
 - **Polished Website** – Expand `site/` with a consistent design language, responsive layout, and more detailed content extracted from the PDF.
-- **Interactive Tools** – Basic experience calculator and persistent checklists are now included on the site; future updates will expand these tools.
+- **Interactive Tools** – The site now includes calculators, checklists, a light/dark theme toggle, and responsive navigation. Future updates will expand these tools further.
 - **Testing Setup** – Integrate automated linting or HTML validation for quality assurance.
 - **User Accounts & Progress Tracking** – Implement authentication and cloud storage so players can save skill levels, quest completion, and gear setups across devices.
 - **Live Data Integration** – Sync calculators with OSRS APIs for real-time item prices, experience tables, and high-score statistics.

--- a/site/index.html
+++ b/site/index.html
@@ -22,6 +22,7 @@
                 <li><a href="#tools">Tools</a></li>
             </ul>
         </nav>
+        <button id="theme-toggle" aria-label="Toggle theme">Light Mode</button>
     </header>
     <main>
         <section id="introduction">
@@ -77,6 +78,10 @@
                 <li>Crafting and other skills benefit from daily activities like battlestaves and kingdom management.</li>
                 <li>Construction: build oak larders to 74 Construction before switching to dungeon doors.</li>
                 <li>Herblore: use quest rewards to reach 38, then make prayer potions and super sets for profit.</li>
+                <li>Farming: plant herb runs daily and manage the kingdom for a steady income.</li>
+                <li>Hunter: unlock Fossil Island and do bird house runs for passive experience.</li>
+                <li>RuneCrafting: quest to level 50 and train at Guardians of the Rift for fast XP.</li>
+                <li>Fletching: craft broad arrows or darts while AFKing other activities.</li>
             </ul>
         </section>
         <section id="quests">
@@ -176,6 +181,8 @@
             <ul>
                 <li>Add detailed guides for every skill from the PDF.</li>
                 <li>Expand boss strategies with gear setups and inventories.</li>
+                <li>Create user accounts to save progress across devices.</li>
+                <li>Integrate real-time item prices for calculators.</li>
             </ul>
         </section>
     </main>

--- a/site/script.js
+++ b/site/script.js
@@ -1,16 +1,38 @@
-// Smooth scrolling for anchor links
+// Smooth scrolling for anchor links and responsive menu
 const links = document.querySelectorAll('nav a');
+const navList = document.querySelector('nav ul');
+const navToggle = document.querySelector('.nav-toggle');
 links.forEach(link => {
     link.addEventListener('click', e => {
         e.preventDefault();
         const target = document.querySelector(link.getAttribute('href'));
         target.scrollIntoView({ behavior: 'smooth' });
-        const navList = document.querySelector('nav ul');
         if (navList.classList.contains('show')) {
             navList.classList.remove('show');
         }
     });
 });
+
+if (navToggle) {
+    navToggle.addEventListener('click', () => {
+        navList.classList.toggle('show');
+    });
+}
+
+const themeToggle = document.getElementById('theme-toggle');
+if (themeToggle) {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light') {
+        document.body.classList.add('light');
+        themeToggle.textContent = 'Dark Mode';
+    }
+    themeToggle.addEventListener('click', () => {
+        document.body.classList.toggle('light');
+        const light = document.body.classList.contains('light');
+        localStorage.setItem('theme', light ? 'light' : 'dark');
+        themeToggle.textContent = light ? 'Dark Mode' : 'Light Mode';
+    });
+}
 
 // Experience calculator
 function xpForLevel(level) {

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,14 +1,28 @@
+:root {
+    --bg-color: #121212;
+    --text-color: #eee;
+    --header-bg: #1f1f1f;
+    --link-color: #90caf9;
+}
+
 body {
     font-family: Arial, sans-serif;
     margin: 0;
     padding: 0;
     line-height: 1.6;
-    background-color: #121212;
-    color: #eee;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+}
+
+body.light {
+    --bg-color: #ffffff;
+    --text-color: #222222;
+    --header-bg: #eeeeee;
+    --link-color: #0069d9;
 }
 
 header {
-    background-color: #1f1f1f;
+    background-color: var(--header-bg);
     padding: 20px;
     text-align: center;
     position: sticky;
@@ -32,9 +46,23 @@ header h1 {
     display: none;
     background: none;
     border: none;
-    color: #eee;
+    color: var(--text-color);
     font-size: 1.5rem;
     margin-right: 10px;
+}
+
+@media (max-width: 600px) {
+    nav ul {
+        display: none;
+        flex-direction: column;
+        gap: 10px;
+    }
+    nav ul.show {
+        display: flex;
+    }
+    .nav-toggle {
+        display: inline;
+    }
 }
 
 nav ul {
@@ -46,7 +74,7 @@ nav ul {
 }
 
 nav a {
-    color: #90caf9;
+    color: var(--link-color);
     text-decoration: none;
     font-weight: bold;
 }


### PR DESCRIPTION
## Summary
- add light/dark theme variables and responsive menu styles
- implement mobile navigation menu and theme toggle in script
- include theme toggle button in page header
- expand non-combat training tips
- document new features in README

## Testing
- `./scripts/validate_html.sh`

------
https://chatgpt.com/codex/tasks/task_e_68515a7091448323b72d4b9d7a673209